### PR TITLE
fix: InfiniteLoading関連のファイル削除及びvue-infinite-loadingをアンインストール

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -112,10 +112,7 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: [
-    { src: '~plugins/InfiniteLoading.js', mode: 'client' },
-    { src: '~plugins/LazyLoad.js', mode: 'client' },
-  ],
+  plugins: [{ src: '~plugins/LazyLoad.js', mode: 'client' }],
   /*
    ** Nuxt.js dev-modules
    */

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
-    "generate:static": "yarn build & yarn generate",
+    "generate:static": "nuxt build & nuxt generate",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
@@ -26,7 +26,6 @@
     "@nuxtjs/dotenv": "^1.4.0",
     "normalize.css": "^8.0.1",
     "nuxt": "^2.14.0",
-    "vue-infinite-loading": "^2.4.5",
     "vue-lazyload": "^1.3.3"
   },
   "devDependencies": {

--- a/plugins/InfiniteLoading.js
+++ b/plugins/InfiniteLoading.js
@@ -1,4 +1,0 @@
-import Vue from 'vue';
-import InfiniteLoading from 'vue-infinite-loading';
-
-Vue.use(InfiniteLoading);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17345,11 +17345,6 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-infinite-loading@^2.4.5:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/vue-infinite-loading/-/vue-infinite-loading-2.4.5.tgz#cc20fd40af7f20188006443c99b60470cf1de1b3"
-  integrity sha512-xhq95Mxun060bRnsOoLE2Be6BR7jYwuC89kDe18+GmCLVrRA/dU0jrGb12Xu6NjmKs+iTW0AA6saSEmEW4cR7g==
-
 vue-jest@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-3.0.6.tgz#27f79d75dcddbe6b3d8327ca1450a107b9cd6f38"


### PR DESCRIPTION
## 追加機能の内容
<!-- 例: testの導入  -->
1. InfiniteLoading関連のファイル削除
1. vue-infinite-loadingをアンインストール

## 変更点
<!-- 例: test関連ファイルを追加、github actionsのワークフロー設定、見た目上の変化はなし -->
見た目上の変化はなし
上記に加え、build時にエラーが発生したため、yarn generate:staticのscriptsを修正

## 影響
<!-- 例: スナップショットテストを行なったため、大幅なレイアウト変更の際には、スナップショットファイルの削除後にテストを行う必要がある -->
特になし

## 見送った内容
<!-- 例: axios部分のテスト実装に、調査が必要なため、pagesテストの追加は次回に行う -->
特になし

