### PR TITLE
fix: ナビゲーションアイコンのテキスト修正

### DIFF
--- a/components/atoms/BaseNavIcon/BaseNavIcon.vue
+++ b/components/atoms/BaseNavIcon/BaseNavIcon.vue
@@ -2,21 +2,21 @@
   <div class="nav-icon">
     <button @click="btnClick">
       <span
-        class="nav-icon__top"
+        class="nav-icon__border nav-icon__top"
         :class="[isOpen ? 'nav-icon__top--open' : 'nav-icon__top--close']"
       ></span>
       <span
-        class="nav-icon__middle"
+        class="nav-icon__border nav-icon__middle"
         :class="{ 'nav-icon__middle--fade': isOpen }"
       ></span>
       <span
-        class="nav-icon__bottom"
+        class="nav-icon__border nav-icon__bottom"
         :class="[isOpen ? 'nav-icon__bottom--open' : 'nav-icon__bottom--close']"
       ></span>
+      <span class="nav-icon__text">
+        <slot />
+      </span>
     </button>
-    <p class="nav-icon__text">
-      <slot />
-    </p>
   </div>
 </template>
 
@@ -67,7 +67,7 @@ button {
   padding: 0;
 }
 
-span {
+.nav-icon__border {
   display: block;
   height: 2px;
   width: 70%;
@@ -105,7 +105,7 @@ span {
 
 .nav-icon__text {
   display: block;
-  margin-top: 20px;
+  margin-top: 40px;
   color: white;
   font-size: 10px;
 }


### PR DESCRIPTION
## 変更点
<!-- 例: test関連ファイルを追加、github actionsのワークフロー設定、見た目上の変化はなし -->
ナビゲーションアイコンにpタグを使っていたが判定を吸われてる?(テキストが青で覆われコピペの選択状態になる)
ようなのでspanタグに変更

## 影響
<!-- 例: スナップショットテストを行なったため、大幅なレイアウト変更の際には、スナップショットファイルの削除後にテストを行う必要がある -->

## 見送った内容
<!-- 例: axios部分のテスト実装に、調査が必要なため、pagesテストの追加は次回に行う -->

