### PR TITLE
fix: ナビゲーションアイコンのテキスト修正

### DIFF
--- a/components/atoms/BaseNavIcon/BaseNavIcon.vue
+++ b/components/atoms/BaseNavIcon/BaseNavIcon.vue
@@ -2,21 +2,21 @@
   <div class="nav-icon">
     <button @click="btnClick">
       <span
-        class="nav-icon__top"
+        class="nav-icon__border nav-icon__top"
         :class="[isOpen ? 'nav-icon__top--open' : 'nav-icon__top--close']"
       ></span>
       <span
-        class="nav-icon__middle"
+        class="nav-icon__border nav-icon__middle"
         :class="{ 'nav-icon__middle--fade': isOpen }"
       ></span>
       <span
-        class="nav-icon__bottom"
+        class="nav-icon__border nav-icon__bottom"
         :class="[isOpen ? 'nav-icon__bottom--open' : 'nav-icon__bottom--close']"
       ></span>
+      <span class="nav-icon__text">
+        <slot />
+      </span>
     </button>
-    <p class="nav-icon__text">
-      <slot />
-    </p>
   </div>
 </template>
 
@@ -67,7 +67,7 @@ button {
   padding: 0;
 }
 
-span {
+.nav-icon__border {
   display: block;
   height: 2px;
   width: 70%;
@@ -105,7 +105,7 @@ span {
 
 .nav-icon__text {
   display: block;
-  margin-top: 20px;
+  margin-top: 40px;
   color: white;
   font-size: 10px;
 }

--- a/components/atoms/BaseNavIcon/__snapshots__/BaseNavIcon.test.js.snap
+++ b/components/atoms/BaseNavIcon/__snapshots__/BaseNavIcon.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavIcon 閉じる時(開くアイコン表示) 1`] = `
-"<div class=\\"nav-icon\\"><button><span class=\\"nav-icon__top nav-icon__top--close\\"></span> <span class=\\"nav-icon__middle\\"></span> <span class=\\"nav-icon__bottom nav-icon__bottom--close\\"></span></button>
-  <p class=\\"nav-icon__text\\">NAVI</p>
-</div>"
-`;
+exports[`NavIcon 閉じる時(開くアイコン表示) 1`] = `"<div class=\\"nav-icon\\"><button><span class=\\"nav-icon__border nav-icon__top nav-icon__top--close\\"></span> <span class=\\"nav-icon__border nav-icon__middle\\"></span> <span class=\\"nav-icon__border nav-icon__bottom nav-icon__bottom--close\\"></span> <span class=\\"nav-icon__text\\">NAVI</span></button></div>"`;
 
-exports[`NavIcon 開いた時(閉じるアイコン表示) 1`] = `
-"<div class=\\"nav-icon\\"><button><span class=\\"nav-icon__top nav-icon__top--open\\"></span> <span class=\\"nav-icon__middle nav-icon__middle--fade\\"></span> <span class=\\"nav-icon__bottom nav-icon__bottom--open\\"></span></button>
-  <p class=\\"nav-icon__text\\">NAVI</p>
-</div>"
-`;
+exports[`NavIcon 開いた時(閉じるアイコン表示) 1`] = `"<div class=\\"nav-icon\\"><button><span class=\\"nav-icon__border nav-icon__top nav-icon__top--open\\"></span> <span class=\\"nav-icon__border nav-icon__middle nav-icon__middle--fade\\"></span> <span class=\\"nav-icon__border nav-icon__bottom nav-icon__bottom--open\\"></span> <span class=\\"nav-icon__text\\">NAVI</span></button></div>"`;

--- a/components/molecules/NavBar/__snapshots__/NavBar.test.js.snap
+++ b/components/molecules/NavBar/__snapshots__/NavBar.test.js.snap
@@ -5,11 +5,9 @@ exports[`NavBar ナビゲーションバーを閉じる 1`] = `
   <div class=\\"nav-bar\\">
     <div class=\\"nav-bar__box\\">
       <div><a href=\\"/\\" class=\\"base-logo\\">ダミーロゴ</a></div>
-      <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__top nav-icon__top--close\\"></span> <span class=\\"nav-icon__middle\\"></span> <span class=\\"nav-icon__bottom nav-icon__bottom--close\\"></span></button>
-        <p class=\\"nav-icon__text\\">
-          NAVI
-        </p>
-      </div>
+      <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__border nav-icon__top nav-icon__top--close\\"></span> <span class=\\"nav-icon__border nav-icon__middle\\"></span> <span class=\\"nav-icon__border nav-icon__bottom nav-icon__bottom--close\\"></span> <span class=\\"nav-icon__text\\">
+        NAVI
+      </span></button></div>
     </div>
   </div>
 </div>"
@@ -20,11 +18,9 @@ exports[`NavBar ナビゲーションバーを開く 1`] = `
   <div class=\\"nav-bar\\">
     <div class=\\"nav-bar__box\\">
       <div><a href=\\"/\\" class=\\"base-logo\\">ダミーロゴ</a></div>
-      <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__top nav-icon__top--open\\"></span> <span class=\\"nav-icon__middle nav-icon__middle--fade\\"></span> <span class=\\"nav-icon__bottom nav-icon__bottom--open\\"></span></button>
-        <p class=\\"nav-icon__text\\">
-          CLOSE
-        </p>
-      </div>
+      <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__border nav-icon__top nav-icon__top--open\\"></span> <span class=\\"nav-icon__border nav-icon__middle nav-icon__middle--fade\\"></span> <span class=\\"nav-icon__border nav-icon__bottom nav-icon__bottom--open\\"></span> <span class=\\"nav-icon__text\\">
+        CLOSE
+      </span></button></div>
     </div>
   </div>
 </div>"

--- a/components/organisms/TheNavigation/__snapshots__/TheNavigation.test.js.snap
+++ b/components/organisms/TheNavigation/__snapshots__/TheNavigation.test.js.snap
@@ -7,11 +7,9 @@ exports[`TheNavigation 閉じた時のスナップショット 1`] = `
       <div class=\\"nav-bar\\">
         <div class=\\"nav-bar__box\\">
           <div><a href=\\"/\\" class=\\"base-logo\\">ダミーロゴ</a></div>
-          <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__top nav-icon__top--close\\"></span> <span class=\\"nav-icon__middle\\"></span> <span class=\\"nav-icon__bottom nav-icon__bottom--close\\"></span></button>
-            <p class=\\"nav-icon__text\\">
-              NAVI
-            </p>
-          </div>
+          <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__border nav-icon__top nav-icon__top--close\\"></span> <span class=\\"nav-icon__border nav-icon__middle\\"></span> <span class=\\"nav-icon__border nav-icon__bottom nav-icon__bottom--close\\"></span> <span class=\\"nav-icon__text\\">
+        NAVI
+      </span></button></div>
         </div>
       </div>
     </div>
@@ -54,11 +52,9 @@ exports[`TheNavigation 開いた時のスナップショット 1`] = `
       <div class=\\"nav-bar\\">
         <div class=\\"nav-bar__box\\">
           <div><a href=\\"/\\" class=\\"base-logo\\">ダミーロゴ</a></div>
-          <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__top nav-icon__top--open\\"></span> <span class=\\"nav-icon__middle nav-icon__middle--fade\\"></span> <span class=\\"nav-icon__bottom nav-icon__bottom--open\\"></span></button>
-            <p class=\\"nav-icon__text\\">
-              CLOSE
-            </p>
-          </div>
+          <div class=\\"nav-icon\\"><button><span class=\\"nav-icon__border nav-icon__top nav-icon__top--open\\"></span> <span class=\\"nav-icon__border nav-icon__middle nav-icon__middle--fade\\"></span> <span class=\\"nav-icon__border nav-icon__bottom nav-icon__bottom--open\\"></span> <span class=\\"nav-icon__text\\">
+        CLOSE
+      </span></button></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 変更点
<!-- 例: test関連ファイルを追加、github actionsのワークフロー設定、見た目上の変化はなし -->
ナビゲーションアイコンにpタグを使っていたが判定を吸われてる?(テキストが青で覆われコピペの選択状態になる)ようなのでspanタグに変更

## 影響
<!-- 例: スナップショットテストを行なったため、大幅なレイアウト変更の際には、スナップショットファイルの削除後にテストを行う必要がある -->

## 見送った内容
<!-- 例: axios部分のテスト実装に、調査が必要なため、pagesテストの追加は次回に行う -->

